### PR TITLE
Changes to the R package install recipe

### DIFF
--- a/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
+++ b/lib/tool_shed/galaxy_install/tool_dependencies/recipe/step_handler.py
@@ -1372,8 +1372,8 @@ class SetupREnvironment( Download, RecipeStep ):
                     # Use raw strings so that python won't automatically unescape the quotes before passing the command
                     # to subprocess.Popen.
                     cmd = r'''PATH=$PATH:$R_HOME/bin; export PATH; R_LIBS=$INSTALL_DIR:$R_LIBS; export R_LIBS;
-                        Rscript -e "install.packages(c('%s'),lib='$INSTALL_DIR', repos=NULL, dependencies=FALSE))"
-                        2>&1 >/dev/null | grep 'had non-zero exit status' && exit 1 || exit 0
+                        Rscript -e "install.packages(c('%s'),lib='$INSTALL_DIR', repos=NULL, dependencies=FALSE)"
+                        2>&1 | (egrep 'had non-zero exit status|unable to install packages|Execution halted' && exit 1) || exit 0
                         ''' % \
                         ( str( tarball_name ) )
                     cmd = install_environment.build_command( basic_util.evaluate_template( cmd, install_environment ) )


### PR DESCRIPTION
I have removed 1 bracket that was too much
I have removed piping to `/dev/null` (because that takes away the input for `grep`)
I have added a few extra grep scentences, which pop up when I tested with an incorrect INSTALL_DIR but a valid R pacakge.

I have tested this with:
BiocGenerics_0.14.0.tar.gz and correct install dir: "exit 0"
DOESNOTEXIST.tar.gz and correct install dir: "exit 1"
BiocGenerics_0.14.0.tar.gz and incorrect install dir: "exit 1"
DOESNOTEXIST.tar.gz and incorrect install dir: "exit 1"

The only worry I have is that this way of installing will have very sparse output in INSTALLATION.log. If the installation fails you will get one of these error messages:

```
  unable to install packages
Execution halted
```

or:

```
  installation of package ‘DOESNOTEXIST.tar.gz’ had non-zero exit status
exit 1
```

Which is not really helpful for debugging.
