### PR TITLE
Revise HTCondor Docker image resolution.

### DIFF
--- a/config/job_conf.xml.sample_advanced
+++ b/config/job_conf.xml.sample_advanced
@@ -446,13 +446,14 @@
                     <container type="docker">bgruening/galaxy-stable</container>
                 </requirements>
 
-                If not the container specified with id="docker_image" is used and as last resort
-                id="docker_default_container_id" is considered.
+            Unless the job destination specifies an override 
+            with docker_container_id_override. If neither of 
+            these is set a default container can be specified
+            with docker_default_container_id. The resolved
+            container ID will be passed along to condor as
+            the docker_image submission parameter.
             -->
-
-            <!-- <param id="docker_image">busybox:ubuntu-14.04</param> -->
             <!-- <param id="docker_default_container_id">busybox:ubuntu-14.04</param> -->
-
         </destination>
 
         <!-- Jobs that hit the walltime on one destination can be automatically

--- a/lib/galaxy/jobs/runners/condor.py
+++ b/lib/galaxy/jobs/runners/condor.py
@@ -60,12 +60,7 @@ class CondorJobRunner( AsynchronousJobRunner ):
         container = None
         universe = query_params.get('universe', False)
         if universe.strip().lower() == 'docker':
-            if job_wrapper.tool.containers:
-                # Try to extract the container (1) from the Tool, (2) from 'docker_image'
-                # and (3) from 'docker_default_container_id'. The last two can be specified in job_conf.xml
-                container = job_wrapper.tool.containers[0].identifier or \
-                    query_params.get('docker_image', False) or \
-                    query_params.get('docker_default_container_id', False)
+            container = self.find_container( job_wrapper )
             if container:
                 # HTCondor needs the image as 'docker_image'
                 query_params.update({'docker_image': container})

--- a/lib/galaxy/tools/deps/containers.py
+++ b/lib/galaxy/tools/deps/containers.py
@@ -107,7 +107,11 @@ class ContainerFinder(object):
     def __default_container_id(self, container_type, destination_info):
         if not self.__container_type_enabled(container_type, destination_info):
             return None
-        return destination_info.get("%s_default_container_id" % container_type)
+        key = "%s_default_container_id" % container_type
+        # Also allow docker_image...
+        if key not in destination_info:
+            key = "%s_image" % container_type
+        return destination_info.get(key)
 
     def __destination_container(self, container_id, container_type, tool_info, destination_info, job_info):
         # TODO: ensure destination_info is dict-like


### PR DESCRIPTION
Bring inline with the rest of the job runner's Docker image resolution stuff. Order of reosolution is:
- Use destination specified override if found: docker_container_id_override
- Use the tool specified container if not found and no override: see tool
- Else - use docker_default_container_id.

This adjusts the documentation to reflect this and make the the parameters more consistent throughout. I've modified this so docker_image (the old name introduced by the Docker Condor PR) still works - but I have left it undocumented intentionally for consistency.
