### PR TITLE
lexists vs. exists

### DIFF
--- a/lib/galaxy/tools/deps/installable.py
+++ b/lib/galaxy/tools/deps/installable.py
@@ -64,7 +64,7 @@ def ensure_installed(installable_context, install_func, auto_init):
             installed = True
         return installed
 
-    if not os.path.exists(parent_path):
+    if not os.path.lexists(parent_path):
         os.mkdir(parent_path)
 
     try:


### PR DESCRIPTION
I have a wired behavior in Docker, in which the `os.path.exists(parent_path)` seems to return False but the path exists, it's a symlink. This results in the following error:

```
Traceback (most recent call last):
  File "lib/galaxy/webapps/galaxy/buildapp.py", line 55, in paste_app_factory
    app = galaxy.app.UniverseApplication( global_conf=global_conf, **kwargs )
  File "lib/galaxy/app.py", line 98, in __init__
    self._configure_toolbox()
  File "lib/galaxy/config.py", line 856, in _configure_toolbox
    self.reload_toolbox()
  File "lib/galaxy/config.py", line 840, in reload_toolbox
    self.toolbox = tools.ToolBox( tool_configs, self.config.tool_path, self )
  File "lib/galaxy/tools/__init__.py", line 116, in __init__
    tool_conf_watcher=tool_conf_watcher
  File "lib/galaxy/tools/toolbox/base.py", line 1068, in __init__
    self._init_dependency_manager()
  File "lib/galaxy/tools/toolbox/base.py", line 1081, in _init_dependency_manager
    self.dependency_manager = build_dependency_manager( self.app.config )
  File "lib/galaxy/tools/deps/__init__.py", line 57, in build_dependency_manager
    dependency_manager = DependencyManager( **dependency_manager_kwds )
  File "lib/galaxy/tools/deps/__init__.py", line 100, in __init__
    self.dependency_resolvers = self.__build_dependency_resolvers( conf_file )
  File "lib/galaxy/tools/deps/__init__.py", line 147, in __build_dependency_resolvers
    return self.__default_dependency_resolvers()
  File "lib/galaxy/tools/deps/__init__.py", line 156, in __default_dependency_resolvers
    CondaDependencyResolver(self),
  File "lib/galaxy/tools/deps/resolvers/conda.py", line 97, in __init__
    self.disabled = not galaxy.tools.deps.installable.ensure_installed(conda_context, install_conda, self.auto_init)
  File "lib/galaxy/tools/deps/installable.py", line 68, in ensure_installed
    os.mkdir(parent_path)
OSError: [Errno 17] File exists: '/export/tool_deps'
```

According to the docs https://docs.python.org/2/library/os.path.html#os.path.lexists `lexists` should also return True for a broken symlink, which at least in this case would not crash in the `os.mkdir` step. I'm a little bit puzzled why this fails at all, because this is a valid symlink, but lexists seems to be more correct here.

We might warn in case of a broken symlink but this is a different question.


