### PR TITLE
Fix test and add datatypes to test/functional/tools/sample_datatypes_…

### DIFF
--- a/lib/galaxy/datatypes/sniff.py
+++ b/lib/galaxy/datatypes/sniff.py
@@ -337,7 +337,7 @@ def guess_ext(fname, sniff_order):
     'bam'
     >>> fname = get_test_fname('3unsorted.bam')
     >>> guess_ext(fname, sniff_order)
-    'bam'
+    'bam_native'
     >>> fname = get_test_fname('test.idpDB')
     >>> guess_ext(fname, sniff_order)
     'idpdb'

--- a/test/functional/tools/sam_to_bam_native.xml
+++ b/test/functional/tools/sam_to_bam_native.xml
@@ -3,23 +3,34 @@
         <requirement type="package" version="1.6">samtools</requirement>
     </requirements>
     <command><![CDATA[
+    #if $input1:
         samtools view
             -b
             -@ \${GALAXY_SLOTS:-2}
             -o '${output}'
-            '$input'
+            '$input1'
+    #else
+        cp '$input2' '$output'
+    #end if
     ]]>
     </command>
     <inputs>
-        <param name="input" type="data" format="sam" label="SAM file"/>
+        <param name="input1" type="data" format="sam" label="SAM file" optional="true"/>
+        <param name="input2" type="data" format="bam_native" label="Unsorted BAM file" optional="true"/>
     </inputs>
     <outputs>
         <data name="output" format="bam_native"/>
     </outputs>
     <tests>
+        <!-- Test that bam native output won't be sorted-->
         <test>
             <param name="input1" value="sam_with_header.sam" ftype="sam"/>
-            <output name="outfile1" file="bam_native_from_sam.bam" ftype="bam_native"/>
+            <output name="output" file="bam_native_from_sam.bam" ftype="bam_native"/>
+        </test>
+        <!-- Test that sam input is properly converted to bam native -->
+        <test>
+            <param name="input2" value="sam_with_header.sam" ftype="sam"/>
+            <output name="output" file="bam_native_from_sam.bam" ftype="bam_native"/>
         </test>
     </tests>
     <help>

--- a/test/functional/tools/sample_datatypes_conf.xml
+++ b/test/functional/tools/sample_datatypes_conf.xml
@@ -14,8 +14,16 @@
     <datatype extension="fastqsolexa" type="galaxy.datatypes.sequence:FastqSolexa" display_in_upload="true" />
     <datatype extension="fastqcssanger" type="galaxy.datatypes.sequence:FastqCSSanger" display_in_upload="true" />
     <datatype extension="fastqillumina" type="galaxy.datatypes.sequence:FastqIllumina" display_in_upload="true" />
-    <datatype extension="sam" type="galaxy.datatypes.tabular:Sam" display_in_upload="true" />
+    <datatype extension="sam" type="galaxy.datatypes.tabular:Sam" display_in_upload="true">
+        <converter file="sam_to_bam.xml" target_datatype="bam"/>
+        <converter file="sam_to_bam_native.xml" target_datatype="bam_native"/>
+        <converter file="sam_to_bigwig_converter.xml" target_datatype="bigwig"/>
+    </datatype>
     <datatype extension="bam" type="galaxy.datatypes.binary:Bam" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://galaxyproject.org/learn/datatypes/#bam" />
+    <datatype extension="bam_native" type="galaxy.datatypes.binary:BamNative" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bam' file extension." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#BAM">
+      <converter file="bam_to_bigwig_converter.xml" target_datatype="bigwig"/>
+      <converter file="bam_native_to_bam_converter.xml" target_datatype="bam"/>
+    </datatype>
     <datatype extension="bcf" type="galaxy.datatypes.binary:Bcf" mimetype="application/octet-stream" display_in_upload="true" description="A binary file compressed in the BGZF format with a '.bcf' file extension." description_url="https://galaxyproject.org/learn/datatypes/#bcf" />
     <datatype extension="biom1" type="galaxy.datatypes.text:Biom1" display_in_upload="True" subclass="True" mimetype="application/json"/>
     <datatype extension="bed" type="galaxy.datatypes.interval:Bed" display_in_upload="true" description="BED format provides a flexible way to define the data lines that are displayed in an annotation track. BED lines have three required columns and nine additional optional columns. The three required columns are chrom, chromStart and chromEnd." description_url="https://galaxyproject.org/learn/datatypes/#bed">


### PR DESCRIPTION
…conf.xml

This test is still failing because `CONVERTER_sam_to_bam` will be invoked instead
of CONVERTER_sam_to_bam_native. Possibly because Bam inherits from BamNative, so
this isn't strictly speaking wrong, though not what one would expect.