### PR TITLE
Fix tests and revert additional sorting of converters

### DIFF
--- a/config/datatypes_conf.xml.sample
+++ b/config/datatypes_conf.xml.sample
@@ -288,8 +288,8 @@
     <datatype extension="qual454" type="galaxy.datatypes.qualityscore:QualityScore454" display_in_upload="true"/>
     <datatype extension="roadmaps" type="galaxy.datatypes.assembly:Roadmaps" display_in_upload="false"/>
     <datatype extension="sam" type="galaxy.datatypes.tabular:Sam" display_in_upload="true">
-        <converter file="sam_to_bam.xml" target_datatype="bam"/>
         <converter file="sam_to_bam_native.xml" target_datatype="bam_native"/>
+        <converter file="sam_to_bam.xml" target_datatype="bam"/>
         <converter file="sam_to_bigwig_converter.xml" target_datatype="bigwig"/>
     </datatype>
     <datatype extension="scf" type="galaxy.datatypes.binary:Scf" mimetype="application/octet-stream" display_in_upload="true" description="A binary sequence file in 'scf' format with a '.scf' file extension.  You must manually select this 'File Format' when uploading the file." description_url="https://wiki.galaxyproject.org/Learn/Datatypes#Scf"/>

--- a/lib/galaxy/datatypes/converters/sam_to_bam_native.xml
+++ b/lib/galaxy/datatypes/converters/sam_to_bam_native.xml
@@ -6,6 +6,7 @@
     <command><![CDATA[
         samtools view
             -b
+            -h
             -@ \${GALAXY_SLOTS:-2}
             -o '${output}'
             '$input'

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -804,7 +804,6 @@ class Registry(object):
             converters = odict()
             source_datatype = type(self.get_datatype_by_extension(ext))
             for ext2, converters_dict in self.datatype_converters.items():
-
                 converter_datatype = type(self.get_datatype_by_extension(ext2))
                 if issubclass(source_datatype, converter_datatype):
                     converters.update(converters_dict)
@@ -823,21 +822,7 @@ class Registry(object):
 
     def find_conversion_destination_for_dataset_by_extensions(self, dataset, accepted_formats, converter_safe=True):
         """Returns ( target_ext, existing converted dataset )"""
-
-        converters = self.get_converters_by_datatype(dataset.ext)
-        new_order = odict()
-
-        accepted_format_keys = list()
-        for k in accepted_formats:
-            accepted_format_keys.append(k.file_ext)
-            if k.file_ext in converters:
-                new_order[k.file_ext] = converters[k.file_ext]
-
-        for k,v in converters.items():
-            if not k in accepted_format_keys:
-                new_order[k] = v
-
-        for convert_ext in new_order:
+        for convert_ext in self.get_converters_by_datatype(dataset.ext):
             convert_ext_datatype = self.get_datatype_by_extension(convert_ext)
             if convert_ext_datatype is None:
                 self.log.warning("Datatype class not found for extension '%s', which is used as target for conversion from datatype '%s'" % (convert_ext, dataset.ext))

--- a/lib/galaxy/datatypes/registry.py
+++ b/lib/galaxy/datatypes/registry.py
@@ -801,7 +801,7 @@ class Registry(object):
     def get_converters_by_datatype(self, ext, priority_formats=None):
         """
             Returns available converters by source type.
-            `priority_formats` will contain a list of format extensions that should
+            `priority_formats` will contain a lis of format extensions that should
             be handled with priority. This means they will end up infront of the
             returned ordered dictionary.
         """

--- a/test/functional/tools/sam_to_bam_native.xml
+++ b/test/functional/tools/sam_to_bam_native.xml
@@ -8,30 +8,39 @@
             -b
             -h
             -@ \${GALAXY_SLOTS:-2}
-            -o '${output}'
+            -o '$bam_native_output'
             '$input1'
-    #else
-        cp '$input2' '$output'
+    #elif $input2:
+        cp '$input2' '$bam_native_output'
+    #elif $input3:
+        cp '$input3' '$bam_output'
     #end if
     ]]>
     </command>
     <inputs>
         <param name="input1" type="data" format="sam" label="SAM file" optional="true"/>
         <param name="input2" type="data" format="bam_native" label="Unsorted BAM file" optional="true"/>
+        <param name="input3" type="data" format="bam" label="Sorted BAM file" optional="true"/>
     </inputs>
     <outputs>
-        <data name="output" format="bam_native"/>
+        <data name="bam_native_output" format="bam_native"/>
+        <data name="bam_output" format="bam"/>
     </outputs>
     <tests>
         <!-- Test that bam native output won't be sorted-->
         <test>
             <param name="input1" value="sam_with_header.sam" ftype="sam"/>
-            <output name="output" file="bam_native_from_sam.bam" ftype="bam_native"/>
+            <output name="bam_native_output" file="bam_native_from_sam.bam" ftype="bam_native"/>
         </test>
         <!-- Test that sam input is properly converted to bam native -->
         <test>
             <param name="input2" value="sam_with_header.sam" ftype="sam"/>
-            <output name="output" file="bam_native_from_sam.bam" ftype="bam_native"/>
+            <output name="bam_native_output" file="bam_native_from_sam.bam" ftype="bam_native"/>
+        </test>
+        <!-- Test that sam input is properly converted to bam -->
+        <test>
+            <param name="input3" value="sam_with_header.sam" ftype="sam"/>
+            <output name="bam_output" file="bam_from_sam.bam" ftype="bam"/>
         </test>
     </tests>
     <help>

--- a/test/functional/tools/sam_to_bam_native.xml
+++ b/test/functional/tools/sam_to_bam_native.xml
@@ -6,6 +6,7 @@
     #if $input1:
         samtools view
             -b
+            -h
             -@ \${GALAXY_SLOTS:-2}
             -o '${output}'
             '$input1'


### PR DESCRIPTION
49dd02f should be the fix for the failing tests, we need to keep the headers.

I have reverted the manual re-ordering of the converters and added a test that demonstrates that when converting input for `format="bam"` the `sam_to_bam` converter will be used instead of the higher priority `sam_to_bam_native` (which isn't compatible with `bam` input).