### PR TITLE
Tweaks to hdf5 testing.

### DIFF
--- a/lib/galaxy/tools/verify/asserts/hdf5.py
+++ b/lib/galaxy/tools/verify/asserts/hdf5.py
@@ -1,19 +1,31 @@
 import io
 
-import h5py
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+IMPORT_MISSING_MESSAGE = "h5 assertion requires unavailable optional dependency h5py"
 
 
-def assert_has_attr(output_bytes, name, value):
+def _assert_h5py():
+    if h5py is None:
+        raise Exception(IMPORT_MISSING_MESSAGE)
+
+
+def assert_has_h5_attribute(output_bytes, name, value):
     """Asserts the specified HDF5 output has a given key-value pair as HDF5
     attribute"""
+    _assert_h5py()
     output_temp = io.BytesIO(output_bytes)
     local_attrs = h5py.File(output_temp, 'r').attrs
     assert name in local_attrs and str(local_attrs[name]) == value, (
         "Not a HDF5 file or H5 attributes do not match:\n\t%s\n\n\t(%s : %s)" % (local_attrs.items(), name, value))
 
 
-def assert_has_keys(output_bytes, keys):
+def assert_has_h5_keys(output_bytes, keys):
     """ Asserts the specified HDF5 output has exactly the given keys."""
+    _assert_h5py()
     keys = [k.strip() for k in keys.strip().split(',')]
     h5_keys = sorted(keys)
     output_temp = io.BytesIO(output_bytes)

--- a/lib/galaxy/tools/xsd/galaxy.xsd
+++ b/lib/galaxy/tools/xsd/galaxy.xsd
@@ -1651,20 +1651,37 @@ module.
           <xs:documentation><![CDATA[This tag allows the developer to recurisively specify additional assertions as child elements about just the text contained in the element specified by the XPath-like ``path`` (e.g. ``<element_text path="BlastOutput_iterations/Iteration/Iteration_hits/Hit/Hit_def"><not_has_text text="EDK72998.1" /></element_text>``).]]></xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element name="has_keys" type="xs:anyType">
-        <xs:annotation>
-          <xs:documentation><![CDATA[Asserts HDF5 output contains the specified ``keys`` (h5py.File().keys()) (e.g. ``<has_keys keys="bins, chroms,indexes,pixels" />``).]]>
-          </xs:documentation>
-        </xs:annotation>
+      <xs:element name="has_h5_keys" type="AssertHasH5Keys">
       </xs:element>
-      <xs:element name="has_attr" type="xs:anyType">
-        <xs:annotation>
-          <xs:documentation><![CDATA[Asserts HDF5 output contains the specified key-vaue pair given as ``name`` and ``value`` (e.g. ``<has_attr name="nchroms" value="15" />``).]]>
-          </xs:documentation>
-        </xs:annotation>
+      <xs:element name="has_h5_attribute" type="AssertHasH5Attribute">
       </xs:element>
     </xs:choice>
   </xs:group>
+  <xs:complexType name="AssertHasH5Keys">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[Asserts HDF5 output contains the specified ``keys`` (h5py.File().keys()) (e.g. ``<has_h5_keys keys="bins, chroms,indexes,pixels" />``).]]></xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="keys" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Comma separated list of keys to check for.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="AssertHasH5Attribute">
+    <xs:annotation>
+      <xs:documentation xml:lang="en"><![CDATA[Asserts HDF5 output contains the specified key-vaue pair given as ``name`` and ``value`` (e.g. ``<has_attr name="nchroms" value="15" />``).]]></xs:documentation>
+    </xs:annotation>
+    <xs:attribute name="name" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Name to check H5 attribute value of.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="value" type="xs:string">
+      <xs:annotation>
+        <xs:documentation xml:lang="en">Expected value of H5 attribute to check.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
   <xs:complexType name="Inputs">
     <xs:annotation>
       <xs:documentation xml:lang="en"><![CDATA[Consists of all elements that define the

--- a/test/functional/tools/validation_hdf5.xml
+++ b/test/functional/tools/validation_hdf5.xml
@@ -13,9 +13,9 @@
             <param name="input" value="matrix.cool" />
             <output name="output">
                 <assert_contents>
-                    <has_keys keys="bins, chroms,indexes,pixels" />
-                    <has_attr name="nbins" value="33754" />
-                    <has_attr name="nchroms" value="15" />
+                    <has_h5_keys keys="bins, chroms,indexes,pixels" />
+                    <has_h5_attribute name="nbins" value="33754" />
+                    <has_h5_attribute name="nchroms" value="15" />
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
- This is in galaxy-lib so h5py import should probably be conditional.
- Namespace very generic test functions a bit by adding h5 into the names.
- Stricter validation of XSD (the other assertions don't have this but that is problematic on their part), I'm not sure if the docs will render unevenly now though - we may want to revisit that and do this for all the assertions.